### PR TITLE
Add track_pageview to list of available commands

### DIFF
--- a/src/mixpanel-wrapper.js
+++ b/src/mixpanel-wrapper.js
@@ -91,6 +91,7 @@
         'track',
         'track_forms',
         'track_links',
+	'track_pageview',
         'track_with_groups',
         'unregister',
         'people.append',


### PR DESCRIPTION
Add `track_pageview` to the list of commands that the wrapper can pass to the main Mixpanel interface.